### PR TITLE
Quote bash shell output variables

### DIFF
--- a/instrfuzz.sh
+++ b/instrfuzz.sh
@@ -11,8 +11,8 @@ do
 	OUTPUT=$(timeout --foreground 0.25 qemu-system-i386 -boot a -fda instrfuzz.img -accel kvm -nographic 2>/dev/null)
 	if [ "$?" -ne 124 ]; then
 		echo 'Abnormal Signal Detected!'
-		OUTDATE=$(date + '%Y%m%d%H%M%S')
-		echo $OUTPUT > instrfuzz-$OUTDATE.log
+		OUTDATE=$(date +'%Y%m%d%H%M%S')
+		echo "${OUTPUT}" > "instrfuzz-${OUTDATE}.log"
 	fi
-	echo $OUTPUT
+	echo "${OUTPUT}"
 done


### PR DESCRIPTION
Also ninja fixes an issue with the `date` command arguments:

```
Abnormal Signal Detected!
date: extra operand ‘%Y%m%d%H%M%S’
Try 'date --help' for more information.
```